### PR TITLE
Switch to pip.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,19 +1,15 @@
 name: base
 channels:
   - conda-forge
-  - pytorch
-  - nvidia
 dependencies:
   - python=3.12
-  - apprise
   - ffmpeg
   - pip
   - pip:
     - better_profanity
-  - cuda-version=12.1
-  - transformers
-  - accelerate
-  - pytorch 
-  - torchvision 
-  - torchaudio 
-  - pytorch-cuda=12.1
+    - torch
+    - torchvision
+    - torchaudio
+    - transformers
+    - accelerate
+    - apprise


### PR DESCRIPTION
Conda's packages don't seem to stay in sync for all of this so ultimately cuda torch support fails and we end up on cpu all the time. Pip is an even bigger image but, cuda works!