### PR TITLE
Update ttt.py

### DIFF
--- a/ttt.py
+++ b/ttt.py
@@ -70,7 +70,7 @@ def transcribe_transformers(calljson, audiofile):
 
     # Set the return argument to english
     # result = PIPE(audiofile, generate_kwargs={"language": "english"})
-    result = PIPE(audiofile, generate_kwargs={"language": "english"})
+    result = PIPE(audiofile, generate_kwargs={"language": "english", "return_timestamps": False})
     calljson["text"] = result["text"]
     return calljson
 


### PR DESCRIPTION
30 second issue

## Summary by Sourcery

Update the transcription function to prevent timestamps from being included in the result, ensuring only the text is returned.

Enhancements:
- Modify the transcription function to disable the return of timestamps in the result.