### PR TITLE
Enable torch compile.  Which means we need gcc in the env.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.12
   - ffmpeg
+  - gcc
   - pip
   - pip:
     - better_profanity


### PR DESCRIPTION
But this further increases transcription speed.

## Summary by Sourcery

Enable torch compilation for the model's forward pass to enhance transcription speed and performance. Update the environment configuration to include gcc, and improve the transcription function to handle longer audio files by returning timestamps.

New Features:
- Enable static cache and compile the forward pass of the model to improve performance.

Enhancements:
- Set the float32 matrix multiplication precision to high for better performance.
- Update the transcription function to support calls over 30 seconds by returning timestamps.

Build:
- Add gcc to the environment dependencies to support torch compilation.