### PR TITLE
Separate torch / other pip installs

### DIFF
--- a/.github/workflows/arm-publish.yml
+++ b/.github/workflows/arm-publish.yml
@@ -9,7 +9,7 @@ on:
   #schedule:
   #  - cron: '41 19 * * 1'
   push:
-    branches: [ "notorch" ]
+    branches: [ "arm" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
     paths-ignore:

--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,11 @@ dependencies:
   - gcc
   - pip
   - pip:
-    - better_profanity
     - torch
     - torchvision
     - torchaudio
+  - pip:
+    - better_profanity
     - transformers
     - accelerate
     - apprise


### PR DESCRIPTION
This should let us specify the cpu-only torch index for the arm builds

## Summary by Sourcery

Separate torch and other pip installations in the environment.yml file to facilitate specifying the CPU-only torch index for ARM builds and update the GitHub Actions workflow to trigger on the 'arm' branch.

Build:
- Separate torch and other pip installations in environment.yml to allow specifying the CPU-only torch index for ARM builds.

CI:
- Update GitHub Actions workflow to trigger on the 'arm' branch instead of 'notorch'.