### PR TITLE
Drop torch compile

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - python=3.12
   - ffmpeg
-  - gcc
   - pip
   - pip:
     - torch


### PR DESCRIPTION
## Summary by Sourcery

Remove torch.compile usage and related configurations from the model setup, and update the environment dependencies by removing gcc.

Enhancements:
- Remove the use of torch.compile and related configurations for model forward pass.

Build:
- Remove gcc from the environment dependencies.