### PR TITLE
Remove arm build

### DIFF
--- a/.github/workflows/cpu-publish.yml
+++ b/.github/workflows/cpu-publish.yml
@@ -86,7 +86,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/arm64,linux/amd64,
+          platforms: linux/amd64,
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Won't work for openvino branch

## Summary by Sourcery

Build:
- Removes the ARM64 build from the CPU publish workflow.